### PR TITLE
Fix import statement for gaussian_filter in filter module DTSW-7190

### DIFF
--- a/src/dt_state_estimation/lane_filter/lane_filter.py
+++ b/src/dt_state_estimation/lane_filter/lane_filter.py
@@ -2,7 +2,7 @@ from math import floor, sqrt
 from typing import List, Tuple
 
 import numpy as np
-from scipy.ndimage.filters import gaussian_filter
+from scipy.ndimage import gaussian_filter
 from scipy.stats import entropy, multivariate_normal
 
 from . import ILaneFilter


### PR DESCRIPTION
Correct the import path for `gaussian_filter` to ensure proper functionality in the filter module.